### PR TITLE
fix: change Update Readme Contributors workflow trigger from pull_request to push

### DIFF
--- a/.github/workflows/update-readme-contributors.yml
+++ b/.github/workflows/update-readme-contributors.yml
@@ -1,7 +1,10 @@
 # From: https://github.com/marketplace/actions/contribute-list
 name: Update Readme Contributors
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
     contrib-readme-job:


### PR DESCRIPTION
## Summary
Fixed the "Update Readme Contributors" workflow that has never succeeded by changing the event trigger from `pull_request` to `push`.

## Root Cause Analysis (Systematic Debugging)

### Phase 1: Root Cause Investigation
**Current Status:**
- ✅ github pages workflow - NOW SUCCEEDING (after PRs #112 and #113)
- ❌ Update Readme Contributors - Still failing with "Branch not found"

**Error Evidence:**
```
##[error]Branch not found
```

**Historical Evidence:**
- Checked workflow history: **0 successful runs** (has NEVER worked)
- All runs fail with same "Branch not found" error
- Occurs when `auto_detect_branch_protection: true` tries to check branch status

### Phase 2: Pattern Analysis
**Research findings:**
- Read action documentation at https://github.com/marketplace/actions/contribute-list
- Action is designed to run on `push` events to main branch, NOT `pull_request` events
- Documentation example shows:
  ```yaml
  on:
    push:
      branches:
        - main
  ```

**Why it fails on pull_request:**
- In PR context, action checks out the PR branch (e.g., `renovate/actions-checkout-6.x`)
- `auto_detect_branch_protection` tries to check branch protection status
- But the PR branch context doesn't have the proper branch reference
- This causes "Branch not found" error

### Phase 3: Hypothesis
**Hypothesis:** Changing trigger from `pull_request` to `push: branches: [main]` will fix the workflow because:
1. Action will run in the correct context (main branch after merge)
2. Branch protection detection will work properly on main branch
3. Contributor list will update automatically after each merge to main

### Phase 4: Implementation

**Changes Made:**
```diff
- on: [pull_request]
+ on:
+   push:
+     branches:
+       - main
```

**Expected Behavior:**
- Workflow will run AFTER PRs are merged to main
- Action will successfully detect branch protection on main
- README.md contributor list will update automatically
- No more "Branch not found" errors

## Test Plan
- [x] Verify workflow no longer triggers on pull_request events (this PR won't trigger it)
- [ ] After merge: Verify workflow runs successfully on push to main
- [ ] After merge: Verify contributor list in README.md is updated

## Notes
- This workflow configuration was incorrect from the start - the action was never designed to run on PR events
- Once merged, the contributor list should update automatically whenever changes are pushed to main
- The action respects branch protection by creating a PR instead of direct commit when protection is enabled